### PR TITLE
EMD-2274 add twin connector functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,18 @@ npm install
 Configure env variables:
 
 ```
-WS_URL - websocket endpoint
-CP_ID - ID of this VCP
-PASSWORD - if used for OCPP Authentication, otherwise can be left blank
-INITIAL_METER_READINGS - Initial meter readings (passed in Wats)
+WS_URL: websocket endpoint
+CP_ID:  ID of this VCP
+PASSWORD: if used for OCPP Authentication, otherwise can be left blank
+INITIAL_METER_READINGS: Initial meter readings (passed in Wats)
+COUNT:   number of VCPs to load
+CP_PREFIX:  serial number prefix when loading multiple VCPs
+SLEP_TIME: time delay between OCPP commands
+TEST_CHARGE:  flags if test charge will start when program runs
+START_CHANCE: % chance of test charge starting
+DURATION: time of charge duration
+RANDOM_DELAY: random delay time
+TWIN_GUN: flags if VCP will have dual gun connectors
 ```
 
 Run OCPP 1.6:
@@ -33,6 +41,22 @@ Run OCPP 2.0.1:
 
 ```bash
 npx ts-node index_201.ts
+```
+
+Run multiple VCPs:
+
+By default, use ```index_16_load.ts```.  Count will be set to 1 as default. Adjust this figure as needed to load multiple VCPs
+
+```bash
+WS_URL=ws://127.0.0.1:9000 COUNT=100 SLEEP_TIME=1000 CP_PREFIX=TWINGUN_VCP START_CHANCE=100 TEST_CHARGE=false DURATION=2000 RANDOM_DELAY=false TWIN_GUN=false npx ts-node index_16_load.ts
+```
+
+Run Twingun VCP:
+
+please note - if running on local machine, SLEEP_TIME needs to be a longer (1000) otherwise StatusNotifications for both connectors may not come through
+
+```bash
+WS_URL=ws://127.0.0.1:9000 COUNT=1 SLEEP_TIME=1000 CP_PREFIX=TWINGUN_VCP START_CHANCE=100 TEST_CHARGE=false DURATION=2000 RANDOM_DELAY=false TWIN_GUN=true npx ts-node index_16_load.ts
 ```
 
 ## Example

--- a/index_16.ts
+++ b/index_16.ts
@@ -36,7 +36,7 @@ const vcp = new VCP({
 (async () => {
   await vcp.connect();
   // boot twingun
-  bootVCP(vcp, isTwinGun, sleepTime);
+  bootVCP(vcp, sleepTime);
 
   // if TEST_CHARGE=true set in cli, start test charge
   console.log(`Test charge set: ${testCharge}`);

--- a/index_16.ts
+++ b/index_16.ts
@@ -4,6 +4,7 @@ require("dotenv").config();
 import { OcppVersion } from "./src/ocppVersion";
 import { VCP } from "./src/vcp";
 import { getArgs } from './src/getArgs';
+import { sleep } from "./src/utils"
 
 const args:Record<string, any> = getArgs();
 
@@ -14,9 +15,6 @@ const endpoint =
         : `ws://ocpp.${args["ENV"]}.electricmiles.io`
     : args["WS_URL"] ?? process.env["WS_URL"] ?? "ws://ocpp.test.electricmiles.io";
 import { simulateCharge } from "./src/simulateCharge";
-
-const sleep = (delay: number) =>
-  new Promise((resolve) => setTimeout(resolve, delay));
 
 const startChance: number = Number(args["START_CHANCE"] ?? process.env["START_CHANCE"] ?? 500);
 const testCharge: boolean = args["TEST_CHARGE"] ?? process.env["TEST_CHARGE"] === "true" ?? false;

--- a/index_16.ts
+++ b/index_16.ts
@@ -5,7 +5,7 @@ import { OcppVersion } from "./src/ocppVersion";
 import { VCP } from "./src/vcp";
 import { getArgs } from './src/getArgs';
 import { sleep } from "./src/utils"
-import { bootVCP } from "./src/vcp_commands/boot_vcp"
+import { bootVCP } from "./src/vcp_commands/bootVcp"
 
 const args:Record<string, any> = getArgs();
 

--- a/index_16_load.ts
+++ b/index_16_load.ts
@@ -3,7 +3,8 @@ require("dotenv").config();
 
 import { OcppVersion } from "./src/ocppVersion";
 import { VCP } from "./src/vcp";
-import { simulateCharge } from "./src/simulateCharge";
+import { simulateCharge } from "./src/vcp_commands/simulateCharge";
+import { sleep } from "./src/utils"
 
 import { getArgs } from './src/getArgs';
 const args:Record<string, any> = getArgs();
@@ -15,7 +16,6 @@ const args:Record<string, any> = getArgs();
 // load test charge sessions with random start times command:
 // WS_URL=ws://ocpp.test.electricmiles.io CP_ID=VCP_ START_CHANCE=100 TEST_CHARGE=true COUNT=5000 RANDOM_START=true npx ts-node index_16_load.ts
 
-const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
 const idPrefix: string = args["CP_PREFIX"] ?? process.env["CP_PREFIX"] ?? "VCP_";
 const count: number = Number(args["COUNT"] ?? process.env["COUNT"] ?? 5000);
 // x ms between each VCP starting up
@@ -60,7 +60,7 @@ async function run() {
         },
       });
       // Ensure backend has registered the new charger - then send status notification
-      await sleep(100);
+      await sleep(500);
       await vcp.sendAndWait({
         messageId: uuid.v4(),
         action: "StatusNotification",

--- a/index_16_load.ts
+++ b/index_16_load.ts
@@ -4,7 +4,7 @@ require("dotenv").config();
 import { OcppVersion } from "./src/ocppVersion";
 import { VCP } from "./src/vcp";
 import { simulateCharge } from "./src/vcp_commands/simulateCharge";
-import { bootVCP } from "./src/vcp_commands/boot_vcp"
+import { bootVCP } from "./src/vcp_commands/bootVcp"
 import { sleep } from "./src/utils"
 
 import { getArgs } from './src/getArgs';

--- a/index_16_load.ts
+++ b/index_16_load.ts
@@ -44,6 +44,7 @@ async function run() {
       endpoint: endpoint,
       chargePointId: idPrefix + i,
       ocppVersion: OcppVersion.OCPP_1_6,
+      isTwinGun: isTwinGun,
     });
   
     vcpList.push(vcp);
@@ -52,7 +53,7 @@ async function run() {
       // Start each VCP a second apart
       await sleep(i * vcpTimeGap);
       await vcp.connect();
-      bootVCP(vcp, isTwinGun, sleepTime);
+      bootVCP(vcp, sleepTime);
 
     })();
     tasks.push(task);

--- a/index_16_load.ts
+++ b/index_16_load.ts
@@ -70,7 +70,7 @@ async function run() {
       const randomChance = Math.floor(Math.random() * 100);
       console.log(`randomChance: ${randomChance}`)
       if (randomChance <= startChance) {
-        simulateCharge(vcp, duration, randomDelay);
+        return simulateCharge(vcp, duration, randomDelay);
       }
       else {
         return Promise.resolve();

--- a/index_16_load.ts
+++ b/index_16_load.ts
@@ -4,6 +4,7 @@ require("dotenv").config();
 import { OcppVersion } from "./src/ocppVersion";
 import { VCP } from "./src/vcp";
 import { simulateCharge } from "./src/vcp_commands/simulateCharge";
+import { bootVCP } from "./src/vcp_commands/boot_vcp"
 import { sleep } from "./src/utils"
 
 import { getArgs } from './src/getArgs';
@@ -17,13 +18,15 @@ const args:Record<string, any> = getArgs();
 // WS_URL=ws://ocpp.test.electricmiles.io CP_ID=VCP_ START_CHANCE=100 TEST_CHARGE=true COUNT=5000 RANDOM_START=true npx ts-node index_16_load.ts
 
 const idPrefix: string = args["CP_PREFIX"] ?? process.env["CP_PREFIX"] ?? "VCP_";
-const count: number = Number(args["COUNT"] ?? process.env["COUNT"] ?? 5000);
+const count: number = Number(args["COUNT"] ?? process.env["COUNT"] ?? 1);
 // x ms between each VCP starting up
 const vcpTimeGap: number = 500;
+const sleepTime: number = Number(args["SLEEP_TIME"] ?? process.env["SLEEP_TIME"] ?? 500);
 const startChance: number = Number(args["START_CHANCE"] ?? process.env["START_CHANCE"] ?? 100);
 const testCharge: boolean = args["TEST_CHARGE"] ?? process.env["TEST_CHARGE"] === "true" ?? false;
 const duration: number = Number(args["DURATION"] ?? process.env["DURATION"] ?? 60000);
 const randomDelay: boolean = args["RANDOM_DELAY"] ?? process.env["RANDOM_DELAY"] == "true" ?? false;
+const isTwinGun: boolean = args["TWIN_GUN"] ?? process.env["TWIN_GUN"] === "true" ?? false;
 
 const endpoint =
     args["ENV"]
@@ -49,27 +52,8 @@ async function run() {
       // Start each VCP a second apart
       await sleep(i * vcpTimeGap);
       await vcp.connect();
-      await vcp.sendAndWait({
-        messageId: uuid.v4(),
-        action: "BootNotification",
-        payload: {
-          chargePointVendor: "ATESS",
-          chargePointModel: "EVA-07S-SE",
-          chargePointSerialNumber: "S001",
-          firmwareVersion: "1.0.0",
-        },
-      });
-      // Ensure backend has registered the new charger - then send status notification
-      await sleep(500);
-      await vcp.sendAndWait({
-        messageId: uuid.v4(),
-        action: "StatusNotification",
-        payload: {
-          connectorId: 1,
-          errorCode: "NoError",
-          status: "Preparing",
-        },
-      });
+      bootVCP(vcp, isTwinGun, sleepTime);
+
     })();
     tasks.push(task);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,2 +1,4 @@
 export const NOOP = () => {};
+export const delay = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 export const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,2 @@
 export const NOOP = () => {};
-export const delay = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));

--- a/src/v16/transactionManager.ts
+++ b/src/v16/transactionManager.ts
@@ -57,14 +57,14 @@ export class TransactionManager {
     // set vcp mapping for transactions
     this.vcpTransactionMap.set(vcp, transactionId);
 
-    console.log(`transactionID: ${transactionId}`)
+    console.log(`connectorID: ${connectorId}, transactionID: ${transactionId}`)
     // for (const [key, value] of this.transactions.entries()) {
     //   console.log(`Key: ${key}`);
     //   console.log('Value:');
     //   console.log(value);
     // }
     TransactionManager.transactionCount++;
-    console.log(`transaction counts: ${TransactionManager.transactionCount}`)
+    console.log(`connectorID: ${connectorId}, transaction counts: ${TransactionManager.transactionCount}`)
 
   return transactionId;
   }

--- a/src/vcp.ts
+++ b/src/vcp.ts
@@ -21,6 +21,7 @@ interface VCPOptions {
   chargePointId: string;
   basicAuthPassword?: string;
   adminWsPort?: number;
+  isTwinGun?: boolean; // if VCP is twingun, based on cli param
 }
 
 export class VCP {
@@ -30,9 +31,16 @@ export class VCP {
   private isFinishing: boolean = false;
   private isWaiting: boolean = false;
   private lastAction: string = '';
+  public isTwinGun: boolean = false;
+  public connectorIDs: number[];
 
   constructor(private vcpOptions: VCPOptions) {
     this.messageHandler = resolveMessageHandler(vcpOptions.ocppVersion);
+    
+    this.vcpOptions.isTwinGun = this.vcpOptions.isTwinGun ?? false;
+    this.isTwinGun = this.vcpOptions.isTwinGun ?? false;
+    this.connectorIDs = this.initializeConnectorIDs();
+
     if (vcpOptions.adminWsPort) {
       this.adminWs = new WebSocketServer({
         port: vcpOptions.adminWsPort,
@@ -165,6 +173,14 @@ export class VCP {
     delete this.ws;
     delete this.adminWs;
     process.exit(1);
+  }
+
+  // sets array of connectorIDs
+  private initializeConnectorIDs(): number[] {
+    if (this.isTwinGun) {
+      return [1, 2];
+    }
+    return [1];
   }
 
   private _onMessage(message: string) {

--- a/src/vcp.ts
+++ b/src/vcp.ts
@@ -178,7 +178,7 @@ export class VCP {
   // sets array of connectorIDs
   private initializeConnectorIDs(): number[] {
     if (this.isTwinGun) {
-      return [1, 2];
+      return [0, 1, 2];
     }
     return [1];
   }

--- a/src/vcp_commands/bootVcp.ts
+++ b/src/vcp_commands/bootVcp.ts
@@ -6,8 +6,7 @@ import { sleep } from "../utils"
 export async function bootVCP(vcp:VCP, sleepTime: number = 100) {
     if (vcp.isTwinGun) {
         console.log("loading twingun VCP...")
-        // const connector1 = vcp.connectorIDs[0];
-        // const connector2 = vcp.connectorIDs[1];
+
         await sleep(500);
         await vcp.sendAndWait({
             messageId: uuid.v4(),
@@ -31,25 +30,6 @@ export async function bootVCP(vcp:VCP, sleepTime: number = 100) {
               },
             });
           }
-          // await vcp.sendAndWait({
-          //   messageId: uuid.v4(),
-          //   action: "StatusNotification",
-          //   payload: {
-          //     connectorId: connector1,
-          //     errorCode: "NoError",
-          //     status: "Preparing",
-          //   },
-          // });
-          // await sleep(sleepTime);
-          // await vcp.sendAndWait({
-          //   messageId: uuid.v4(),
-          //   action: "StatusNotification",
-          //   payload: {
-          //     connectorId: connector2,
-          //     errorCode: "NoError",
-          //     status: "Preparing",
-          //   },
-          // });
           console.log("twingun VCP successfully loaded...")
     } else {
         console.log("loading single connector VCP...")

--- a/src/vcp_commands/bootVcp.ts
+++ b/src/vcp_commands/bootVcp.ts
@@ -64,16 +64,16 @@ export async function bootVCP(vcp:VCP, sleepTime: number = 100) {
               firmwareVersion: "1.0.0",
             },
           });
-          // await sleep(100);
-          // await vcp.sendAndWait({
-          //   messageId: uuid.v4(),
-          //   action: "StatusNotification",
-          //   payload: {
-          //     connectorId: vcp.connectorIDs[0],
-          //     errorCode: "NoError",
-          //     status: "Preparing",
-          //   },
-          // });
+          await sleep(100);
+          await vcp.sendAndWait({
+            messageId: uuid.v4(),
+            action: "StatusNotification",
+            payload: {
+              connectorId: vcp.connectorIDs[0],
+              errorCode: "NoError",
+              status: "Preparing",
+            },
+          });
           console.log("single connector VCP successfully loaded...")
     }
 }

--- a/src/vcp_commands/bootVcp.ts
+++ b/src/vcp_commands/bootVcp.ts
@@ -1,6 +1,5 @@
 import * as uuid from "uuid";
 import { VCP } from "../vcp";
-// import {transactionManager} from "../v16/transactionManager";
 import { sleep } from "../utils"
 
 export async function bootVCP(vcp:VCP, sleepTime: number = 100) {

--- a/src/vcp_commands/boot_vcp.ts
+++ b/src/vcp_commands/boot_vcp.ts
@@ -1,0 +1,66 @@
+import * as uuid from "uuid";
+import { VCP } from "../vcp";
+// import {transactionManager} from "../v16/transactionManager";
+import { sleep } from "../utils"
+
+export async function bootVCP(vcp:VCP, isTwinGun: boolean=false, sleepTime: number = 100) {
+    if (isTwinGun) {
+        console.log("loading twingun VCP...")
+        await sleep(500);
+        await vcp.sendAndWait({
+            messageId: uuid.v4(),
+            action: "BootNotification",
+            payload: {
+              chargePointVendor: "ATESS",
+              chargePointModel: "EVA-07D-SEW",
+              chargePointSerialNumber: "S001",
+              firmwareVersion: "1.0.0",
+            },
+          });
+          await sleep(sleepTime);
+          await vcp.sendAndWait({
+            messageId: uuid.v4(),
+            action: "StatusNotification",
+            payload: {
+              connectorId: 1,
+              errorCode: "NoError",
+              status: "Preparing",
+            },
+          });
+          await sleep(sleepTime);
+          await vcp.sendAndWait({
+            messageId: uuid.v4(),
+            action: "StatusNotification",
+            payload: {
+              connectorId: 2,
+              errorCode: "NoError",
+              status: "Preparing",
+            },
+          });
+          console.log("twingun VCP successfully loaded...")
+    } else {
+        console.log("loading single connector VCP...")
+        await sleep(100);
+        await vcp.sendAndWait({
+            messageId: uuid.v4(),
+            action: "BootNotification",
+            payload: {
+              chargePointVendor: "ATESS",
+              chargePointModel: "EVA-07S-SE",
+              chargePointSerialNumber: "S001",
+              firmwareVersion: "1.0.0",
+            },
+          });
+          await sleep(100);
+          await vcp.sendAndWait({
+            messageId: uuid.v4(),
+            action: "StatusNotification",
+            payload: {
+              connectorId: 1,
+              errorCode: "NoError",
+              status: "Preparing",
+            },
+          });
+          console.log("single connector VCP successfully loaded...")
+    }
+}

--- a/src/vcp_commands/boot_vcp.ts
+++ b/src/vcp_commands/boot_vcp.ts
@@ -3,9 +3,11 @@ import { VCP } from "../vcp";
 // import {transactionManager} from "../v16/transactionManager";
 import { sleep } from "../utils"
 
-export async function bootVCP(vcp:VCP, isTwinGun: boolean=false, sleepTime: number = 100) {
-    if (isTwinGun) {
+export async function bootVCP(vcp:VCP, sleepTime: number = 100) {
+    if (vcp.isTwinGun) {
         console.log("loading twingun VCP...")
+        const connector1 = vcp.connectorIDs[0];
+        const connector2 = vcp.connectorIDs[1];
         await sleep(500);
         await vcp.sendAndWait({
             messageId: uuid.v4(),
@@ -22,7 +24,7 @@ export async function bootVCP(vcp:VCP, isTwinGun: boolean=false, sleepTime: numb
             messageId: uuid.v4(),
             action: "StatusNotification",
             payload: {
-              connectorId: 1,
+              connectorId: connector1,
               errorCode: "NoError",
               status: "Preparing",
             },
@@ -32,7 +34,7 @@ export async function bootVCP(vcp:VCP, isTwinGun: boolean=false, sleepTime: numb
             messageId: uuid.v4(),
             action: "StatusNotification",
             payload: {
-              connectorId: 2,
+              connectorId: connector2,
               errorCode: "NoError",
               status: "Preparing",
             },
@@ -56,7 +58,7 @@ export async function bootVCP(vcp:VCP, isTwinGun: boolean=false, sleepTime: numb
             messageId: uuid.v4(),
             action: "StatusNotification",
             payload: {
-              connectorId: 1,
+              connectorId: vcp.connectorIDs[0],
               errorCode: "NoError",
               status: "Preparing",
             },

--- a/src/vcp_commands/boot_vcp.ts
+++ b/src/vcp_commands/boot_vcp.ts
@@ -6,8 +6,8 @@ import { sleep } from "../utils"
 export async function bootVCP(vcp:VCP, sleepTime: number = 100) {
     if (vcp.isTwinGun) {
         console.log("loading twingun VCP...")
-        const connector1 = vcp.connectorIDs[0];
-        const connector2 = vcp.connectorIDs[1];
+        // const connector1 = vcp.connectorIDs[0];
+        // const connector2 = vcp.connectorIDs[1];
         await sleep(500);
         await vcp.sendAndWait({
             messageId: uuid.v4(),
@@ -19,26 +19,37 @@ export async function bootVCP(vcp:VCP, sleepTime: number = 100) {
               firmwareVersion: "1.0.0",
             },
           });
-          await sleep(sleepTime);
-          await vcp.sendAndWait({
-            messageId: uuid.v4(),
-            action: "StatusNotification",
-            payload: {
-              connectorId: connector1,
-              errorCode: "NoError",
-              status: "Preparing",
-            },
-          });
-          await sleep(sleepTime);
-          await vcp.sendAndWait({
-            messageId: uuid.v4(),
-            action: "StatusNotification",
-            payload: {
-              connectorId: connector2,
-              errorCode: "NoError",
-              status: "Preparing",
-            },
-          });
+          for (const connectorId of vcp.connectorIDs) {
+            await sleep(sleepTime);
+            await vcp.sendAndWait({
+              messageId: uuid.v4(),
+              action: "StatusNotification",
+              payload: {
+                connectorId: connectorId,
+                errorCode: "NoError",
+                status: "Preparing",
+              },
+            });
+          }
+          // await vcp.sendAndWait({
+          //   messageId: uuid.v4(),
+          //   action: "StatusNotification",
+          //   payload: {
+          //     connectorId: connector1,
+          //     errorCode: "NoError",
+          //     status: "Preparing",
+          //   },
+          // });
+          // await sleep(sleepTime);
+          // await vcp.sendAndWait({
+          //   messageId: uuid.v4(),
+          //   action: "StatusNotification",
+          //   payload: {
+          //     connectorId: connector2,
+          //     errorCode: "NoError",
+          //     status: "Preparing",
+          //   },
+          // });
           console.log("twingun VCP successfully loaded...")
     } else {
         console.log("loading single connector VCP...")
@@ -53,16 +64,16 @@ export async function bootVCP(vcp:VCP, sleepTime: number = 100) {
               firmwareVersion: "1.0.0",
             },
           });
-          await sleep(100);
-          await vcp.sendAndWait({
-            messageId: uuid.v4(),
-            action: "StatusNotification",
-            payload: {
-              connectorId: vcp.connectorIDs[0],
-              errorCode: "NoError",
-              status: "Preparing",
-            },
-          });
+          // await sleep(100);
+          // await vcp.sendAndWait({
+          //   messageId: uuid.v4(),
+          //   action: "StatusNotification",
+          //   payload: {
+          //     connectorId: vcp.connectorIDs[0],
+          //     errorCode: "NoError",
+          //     status: "Preparing",
+          //   },
+          // });
           console.log("single connector VCP successfully loaded...")
     }
 }

--- a/src/vcp_commands/simulateCharge.ts
+++ b/src/vcp_commands/simulateCharge.ts
@@ -1,0 +1,72 @@
+import * as uuid from "uuid";
+import { VCP } from "../vcp";
+import {transactionManager} from "../v16/transactionManager";
+import { sleep } from "../utils"
+
+export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boolean = false) {
+  await sleep(500); 
+  for (let i = 1; i <= 2; i++) {
+    console.log(`charge session count: ${i}`);
+    // if randomDelay, test charge will start between 500-120,000ms
+    if (!randomDelay) {
+      await sleep(500)
+    }
+    else {
+      const minTime = 500;
+      const maxTime = 120000;
+      const randomStart = Math.floor(Math.random() * (maxTime - minTime)) + minTime;
+      console.log(`random delay of ${randomStart} applied...`)
+      await sleep(randomStart);
+    }
+    // initiate P&C charge session
+    await vcp.sendAndWait({
+      action: "StartTransaction",
+      messageId: uuid.v4(),
+      payload: {
+        connectorId: 1,
+        idTag: 'freevenIdTag', // -> for P&C
+        meterStart: parseInt(process.env["INITIAL_METER_READINGS"] ?? "0"),
+        timestamp: new Date(),
+      },
+    });
+    // send charging statusNotification
+    await sleep(500)
+    await vcp.sendAndWait({
+      action: "StatusNotification",
+      messageId: uuid.v4(),
+      payload: {
+        connectorId: 1,
+        errorCode: "NoError",
+        status: "Charging",
+      },
+    });
+    console.log("vcp charging...")
+    // send stopNotification after set duration
+    await sleep(duration);
+    
+    // gets transId by VCP instance
+    let transId = transactionManager.getTransactionIdByVcp(vcp);
+    console.log(`transactionId for stopNotif : ${transId}`);
+  
+    await vcp.sendAndWait({
+      action: "StopTransaction",
+      messageId: uuid.v4(),
+      payload: {
+        transactionId: transId,
+        timestamp: new Date(),
+        meterStop: 2000,
+      },
+    });
+    console.log("StopTransaction is sent...")
+    await sleep(500);
+    await vcp.sendAndWait({
+      action: "StatusNotification",
+      messageId: uuid.v4(),
+      payload: {
+        connectorId: 1,
+        errorCode: "NoError",
+        status: "Finishing",
+      },
+    });
+  }
+}

--- a/src/vcp_commands/simulateCharge.ts
+++ b/src/vcp_commands/simulateCharge.ts
@@ -78,7 +78,6 @@ export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boo
 }
 
 export async function singleTestCharge(vcp: VCP, duration: number,randomDelay: boolean = false, connector: number = 1) {
-  //   const validConnectors = vcp.connectorIDs.filter(connector => connector !== 0);  
   
       console.log(`Starting test charge for connector: ${connector}`);
       await sleep(500); 

--- a/src/vcp_commands/simulateCharge.ts
+++ b/src/vcp_commands/simulateCharge.ts
@@ -4,71 +4,75 @@ import {transactionManager} from "../v16/transactionManager";
 import { sleep } from "../utils"
 
 export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boolean = false) {
-  let connector = vcp.connectorIDs[0]
+  const validConnectors = vcp.connectorIDs.filter(connector => connector !== 0);
 
-  await sleep(500); 
-  for (let i = 1; i <= 2; i++) {
-    console.log(`charge session count: ${i}`);
-    // if randomDelay, test charge will start between 500-120,000ms
-    if (!randomDelay) {
+  const chargePromises = validConnectors.map(async (connector) => {
+    console.log(`Starting test charge for connector: ${connector}`);
+    await sleep(500); 
+    for (let i = 1; i <= 2; i++) {
+      console.log(`charge session count: ${i}`);
+      // if randomDelay, test charge will start between 500-120,000ms
+      if (!randomDelay) {
+        await sleep(500)
+      }
+      else {
+        const minTime = 500;
+        const maxTime = 120000;
+        const randomStart = Math.floor(Math.random() * (maxTime - minTime)) + minTime;
+        console.log(`random delay of ${randomStart} applied...`)
+        await sleep(randomStart);
+      }
+      // initiate P&C charge session
+      await vcp.sendAndWait({
+        action: "StartTransaction",
+        messageId: uuid.v4(),
+        payload: {
+          connectorId: connector,
+          idTag: 'freevenIdTag', // -> for P&C
+          meterStart: parseInt(process.env["INITIAL_METER_READINGS"] ?? "0"),
+          timestamp: new Date(),
+        },
+      });
+      // send charging statusNotification
       await sleep(500)
-    }
-    else {
-      const minTime = 500;
-      const maxTime = 120000;
-      const randomStart = Math.floor(Math.random() * (maxTime - minTime)) + minTime;
-      console.log(`random delay of ${randomStart} applied...`)
-      await sleep(randomStart);
-    }
-    // initiate P&C charge session
-    await vcp.sendAndWait({
-      action: "StartTransaction",
-      messageId: uuid.v4(),
-      payload: {
-        connectorId: 1,
-        idTag: 'freevenIdTag', // -> for P&C
-        meterStart: parseInt(process.env["INITIAL_METER_READINGS"] ?? "0"),
-        timestamp: new Date(),
-      },
-    });
-    // send charging statusNotification
-    await sleep(500)
-    await vcp.sendAndWait({
-      action: "StatusNotification",
-      messageId: uuid.v4(),
-      payload: {
-        connectorId: connector,
-        errorCode: "NoError",
-        status: "Charging",
-      },
-    });
-    console.log("vcp charging...")
-    // send stopNotification after set duration
-    await sleep(duration);
+      await vcp.sendAndWait({
+        action: "StatusNotification",
+        messageId: uuid.v4(),
+        payload: {
+          connectorId: connector,
+          errorCode: "NoError",
+          status: "Charging",
+        },
+      });
+      console.log("vcp charging...")
+      // send stopNotification after set duration
+      await sleep(duration);
+      
+      // gets transId by VCP instance
+      let transId = transactionManager.getTransactionIdByVcp(vcp);
+      console.log(`transactionId for stopNotif : ${transId}`);
     
-    // gets transId by VCP instance
-    let transId = transactionManager.getTransactionIdByVcp(vcp);
-    console.log(`transactionId for stopNotif : ${transId}`);
-  
-    await vcp.sendAndWait({
-      action: "StopTransaction",
-      messageId: uuid.v4(),
-      payload: {
-        transactionId: transId,
-        timestamp: new Date(),
-        meterStop: 2000,
-      },
-    });
-    console.log("StopTransaction is sent...")
-    await sleep(500);
-    await vcp.sendAndWait({
-      action: "StatusNotification",
-      messageId: uuid.v4(),
-      payload: {
-        connectorId: connector,
-        errorCode: "NoError",
-        status: "Finishing",
-      },
-    });
-  }
+      await vcp.sendAndWait({
+        action: "StopTransaction",
+        messageId: uuid.v4(),
+        payload: {
+          transactionId: transId,
+          timestamp: new Date(),
+          meterStop: 2000,
+        },
+      });
+      console.log("StopTransaction is sent...")
+      await sleep(500);
+      await vcp.sendAndWait({
+        action: "StatusNotification",
+        messageId: uuid.v4(),
+        payload: {
+          connectorId: connector,
+          errorCode: "NoError",
+          status: "Finishing",
+        },
+      });
+    }
+  });
+  await Promise.all(chargePromises);
 }

--- a/src/vcp_commands/simulateCharge.ts
+++ b/src/vcp_commands/simulateCharge.ts
@@ -4,6 +4,8 @@ import {transactionManager} from "../v16/transactionManager";
 import { sleep } from "../utils"
 
 export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boolean = false) {
+  let connector = vcp.connectorIDs[0]
+
   await sleep(500); 
   for (let i = 1; i <= 2; i++) {
     console.log(`charge session count: ${i}`);
@@ -35,7 +37,7 @@ export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boo
       action: "StatusNotification",
       messageId: uuid.v4(),
       payload: {
-        connectorId: 1,
+        connectorId: connector,
         errorCode: "NoError",
         status: "Charging",
       },
@@ -63,7 +65,7 @@ export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boo
       action: "StatusNotification",
       messageId: uuid.v4(),
       payload: {
-        connectorId: 1,
+        connectorId: connector,
         errorCode: "NoError",
         status: "Finishing",
       },

--- a/src/vcp_commands/simulateCharge.ts
+++ b/src/vcp_commands/simulateCharge.ts
@@ -34,7 +34,7 @@ export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boo
         },
       });
       // send charging statusNotification
-      await sleep(500)
+      await sleep(1000)
       await vcp.sendAndWait({
         action: "StatusNotification",
         messageId: uuid.v4(),
@@ -76,3 +76,72 @@ export async function simulateCharge(vcp: VCP, duration: number,randomDelay: boo
   });
   await Promise.all(chargePromises);
 }
+
+export async function singleTestCharge(vcp: VCP, duration: number,randomDelay: boolean = false, connector: number = 1) {
+  //   const validConnectors = vcp.connectorIDs.filter(connector => connector !== 0);  
+  
+      console.log(`Starting test charge for connector: ${connector}`);
+      await sleep(500); 
+      // if randomDelay, test charge will start between 500-120,000ms
+      if (!randomDelay) {
+        await sleep(500)
+      }
+      else {
+        const minTime = 500;
+        const maxTime = 120000;
+        const randomStart = Math.floor(Math.random() * (maxTime - minTime)) + minTime;
+        console.log(`random delay of ${randomStart} applied...`)
+        await sleep(randomStart);
+      }
+      // initiate P&C charge session
+      await vcp.sendAndWait({
+        action: "StartTransaction",
+        messageId: uuid.v4(),
+        payload: {
+          connectorId: connector,
+          idTag: 'freevenIdTag', // -> for P&C
+          meterStart: parseInt(process.env["INITIAL_METER_READINGS"] ?? "0"),
+          timestamp: new Date(),
+        },
+      });
+      // send charging statusNotification
+      await sleep(1000)
+      await vcp.sendAndWait({
+        action: "StatusNotification",
+        messageId: uuid.v4(),
+        payload: {
+          connectorId: connector,
+          errorCode: "NoError",
+          status: "Charging",
+        },
+      });
+      console.log("vcp charging...")
+      // send stopNotification after set duration
+      await sleep(duration);
+      
+      // gets transId by VCP instance
+      let transId = transactionManager.getTransactionIdByVcp(vcp);
+      console.log(`transactionId for stopNotif : ${transId}`);
+      
+      await vcp.sendAndWait({
+        action: "StopTransaction",
+        messageId: uuid.v4(),
+        payload: {
+          transactionId: transId,
+          timestamp: new Date(),
+          meterStop: 2000,
+        },
+      });
+      console.log("StopTransaction is sent...")
+      await sleep(500);
+      await vcp.sendAndWait({
+        action: "StatusNotification",
+        messageId: uuid.v4(),
+        payload: {
+          connectorId: connector,
+          errorCode: "NoError",
+          status: "Finishing",
+        },
+      });
+  }
+  


### PR DESCRIPTION
allows VCP to create instance(s) of twingun chargers, with 2 connectors. 

Details:
- added properties isTwinGun and connectorIDs to VCP class
- if twingun, sets connectorsIDs array to [1,2], else [1]
- adds bootVCP function which sends statuses for both connectors, if vcp is twingun
- simulateCharge takes VCP's connectorIDs instead of hard-coded 1 value
- also included custom sleepTime cli param when running program